### PR TITLE
resolve issue 40: ensure duplicate rss entries aren't stored in collection

### DIFF
--- a/feed_bot/bot.py
+++ b/feed_bot/bot.py
@@ -234,15 +234,17 @@ class FeedBot(commands.Bot):
         for entry in entries:
             seconds_since_epoch = time.mktime(entry.published_parsed)
             dt = datetime.fromtimestamp(seconds_since_epoch)
-            insert_dict = {
+            find_dict = {
                 "feed_url": feed_url,
+                "title": entry.title,
                 "thumbnail": thumbnail,
                 "dt_published": dt,
-                **entry,
             }
-            doc = await self.rss_collection.find_one(insert_dict)
+
+            doc = await self.rss_collection.find_one(find_dict)
 
             if not doc:
+                insert_dict = {**find_dict, **entry}
                 result = await self.rss_collection.insert_one(insert_dict)
                 if result.inserted_id:
                     inserted.append(insert_dict)


### PR DESCRIPTION
This PR refactors `find_one_rss_entry_or_insert` to use unique dictionary keys to see if an rss entry is already in the rss collection. If not found, we insert the `find_dict` (unique keys) and the rest o﻿f the entry. This way only unique entries are stored.
