### PR TITLE
Resolves #61 ValueError RSS Feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To open a shell to the noSQL database run
 $ docker compose exec mongo mongosh mongodb://root:feed_bot@mongo:27017/
 ```
 
-[mongodb cheatsheet](https://dev.to/yaswanthteja/all-mongodb-database-commands-mongodb-cheatsheet-146k)
+[mongodb cheatsheet](https://www.mongodb.com/developer/products/mongodb/cheat-sheet/)
 
 To run test cases run
 

--- a/feed_bot/bot.py
+++ b/feed_bot/bot.py
@@ -254,6 +254,7 @@ class FeedBot(commands.Bot):
                     embed = rss.create_entry_embed(entry=entry)
                     embeds.append(embed)
 
+                # Batch the embeds to avoid ValueError thrown by Discord
                 if len(embeds) > 10:
                     embed_batches = chunks(lst=embeds, n=10)
 

--- a/feed_bot/utils/common.py
+++ b/feed_bot/utils/common.py
@@ -21,6 +21,12 @@ def md(soup: BeautifulSoup, **options):
     return MarkdownConverter(**options).convert_soup(soup)
 
 
+def chunks(lst: list, n: int = 10):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
 class CommonUtilities:
     """CommonUtilities for managing class state and aiohttp sessions"""
 


### PR DESCRIPTION
This PR resolves a `ValueError` exception that is thrown when we try to send more than 10 embeds to a channel at a time.
 
﻿- 61-error: send embeds in batches
- 61-error: add comment
